### PR TITLE
Ignore documentation tests of private modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!**.tmp'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings -W clippy::pedantic
+      - name: Detect Cargo.lock changes
+        run: git diff-index --quiet HEAD --
+
+  test:
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/src/hwinfo.rs
+++ b/src/hwinfo.rs
@@ -48,8 +48,10 @@ pub fn diskusage() -> Result<Option<(String, String, String, String)>> {
 }
 
 /// Get system uptime. It's joined result for command `uptime -p` and `uptime -s`
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // Result format:
 /// // how long the system has been running (boot: boot up time)
 /// // up 7 weeks, 5 days, 13 hours, 52 minutes (boot: 2021-12-16 23:43:10)
@@ -77,8 +79,10 @@ pub fn uptime() -> Option<String> {
 }
 
 /// Get OS and Product versions. Refer /etc/version
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// let (os_ver, product_ver) = hwinfo::get_version();
 /// println!("OS version = {}, Product version = {}", os_ver, product_ver);
 /// ```
@@ -111,13 +115,17 @@ pub fn get_version() -> (String, String) {
 }
 
 /// Set OS or Product version. Refer /etc/version
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// hwinfo::set_version(SubCommand::SetOsVersion, "AICE OS v1.0.23").unwrap();
 /// hwinfo::set_version(SubCommand::SetProductVersion, "AICE Security v1.1.99").unwrap();
 /// ```
+///
 /// # Errors
-/// * fail to open or write /etc/version
+///
+/// * fail to open or write `/etc/version`
 pub fn set_version(kind: SubCommand, arg: &str) -> Result<()> {
     let contents = fs::read_to_string(DEFAULT_VERSION_PATH)?;
     let lines = contents.lines();

--- a/src/ifconfig.rs
+++ b/src/ifconfig.rs
@@ -405,11 +405,13 @@ pub fn init(ifname: &str) -> Result<()> {
 /// This command will OVERWRITE all existing setting in the interface if exist.
 ///
 /// # Warning
+///
 /// * if the target interface is not running (cable connected), netplan does not
 ///   set the address to interface. Instead it will just saved it into conf file.
 ///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // To replace(overwrite) ip address, gateway, nameservers of eno3 interface.
 /// let nic_output = NicOutput::new(
 ///     Some(vec!["192.168.0.205/24".to_string(), "192.168.4.7/24".to_string()]),
@@ -468,8 +470,10 @@ pub fn set(ifname: &str, nic_output: &NicOutput) -> Result<()> {
 }
 
 /// Get interface configurations
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // get all interfaces
 /// let all_interfaces = ifconfig::get(&None)?;
 ///
@@ -497,7 +501,8 @@ pub fn get(ifname: &Option<String>) -> Result<Option<Vec<(String, NicOutput)>>> 
 /// Remove interface or name server or gateway address from the specified interface.
 ///
 /// # Example
-///```
+///
+///```ignore
 /// // to delete interface address "192.168.3.7/24", nameserver "164.124.101.2"
 /// let nic_output = NicOutput::new(
 ///     Some(vec!["192.168.3.7/24".to_string()]),
@@ -507,7 +512,9 @@ pub fn get(ifname: &Option<String>) -> Result<Option<Vec<(String, NicOutput)>>> 
 ///
 /// ifconfig::delete("eno3", &nic_output)?;
 ///```
+///
 /// # Errors
+///
 /// * fail to load /etc/netplan yaml files
 /// * fail to apply the change to system
 /// * interface not found
@@ -527,8 +534,10 @@ pub fn delete(ifname: &str, nic_output: &NicOutput) -> Result<()> {
 }
 
 /// Get interface names starting with the specified prefix
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // get interface names starting with "en"
 /// let names = ifconfig::get_interface_names(&Some("en".to_string()));
 /// ```

--- a/src/ntp.rs
+++ b/src/ntp.rs
@@ -7,11 +7,15 @@ use std::io::Write;
 const NTP_CONF: &str = "/etc/ntp.conf";
 
 /// Set NTP server addresses.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// let ret = ntp::set(&vec!["time.bora.net".to_string(), "time2.kriss.re.kr".to_string()])?;
 /// ```
+///
 /// # Errors
+///
 /// * fail to open /etc/ntp.conf
 /// * fail to write modified contents to /etc/ntp.conf
 /// * fail to restart ntp service

--- a/src/sshd.rs
+++ b/src/sshd.rs
@@ -7,11 +7,15 @@ const SSHD_CONFIG: &str = "/etc/ssh/sshd_config";
 const SSHD_DEFAULT_PORT: u16 = 22;
 
 /// Set sshd port.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// let ret = sshd::set("10022")?;
 /// ```
+///
 /// # Errors
+///
 /// * invalid port
 /// * fail to open ``/etc/ssh/sshd_config``
 /// * fail to write modified contents to ``/etc/ssh/sshd_config``
@@ -42,7 +46,9 @@ pub fn set(port: &str) -> Result<bool> {
 }
 
 /// Get sshd port number
+///
 /// # Errors
+///
 /// * fail to open ``/etc/ssh/sshd_config``
 pub fn get() -> Result<u16> {
     let contents = fs::read_to_string(SSHD_CONFIG)?;

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -8,8 +8,10 @@ const RSYSLOG_CONF: &str = "/etc/rsyslog.d/50-default.conf";
 const DEFAULT_FACILITY: &str = "user.*";
 
 /// Set or init rsyslog remote servers. Currently the facility is fixed to `user.*`.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // To set remote addresses:
 /// let cmd = Some(vec![
 ///     "@@192.168.0.205:7500".to_string(), // tcp
@@ -63,8 +65,10 @@ pub fn set(remote_addrs: &Option<Vec<String>>) -> Result<bool> {
 }
 
 /// Get rsyslog remote servers.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// if let Some(addrs) = syslog::get() {
 ///     for (facility, proto, addr) in &addrs {
 ///         println!("facility = {}, proto = {}, dest addr = {}", facility, proto, addr);

--- a/src/ufw.rs
+++ b/src/ufw.rs
@@ -6,13 +6,15 @@ pub type AccessLists = Vec<(String, String, String, Option<String>, Option<Strin
 
 /// Get firewall rules. The result of command `ufw status`.
 /// Currently only return IPv4 rules.
+///
 /// # Return
-///     Vec<(Action, From, To, Protocol, Interface)>
-///     * Action: String,        // ALLOW IN, ALLOW OUT, DENY IN, DENY OUT
-///     * From: String,          // Source address, port (or "Any")
-///     * To: String,            // Destination address, port (or "Any")
-///     * Protocol: Option<String>  // Protocol name
-///     * Interface: Option<String> // Interface name
+///
+/// Vec<(Action, From, To, Protocol, Interface)>
+/// * Action: String,        // ALLOW IN, ALLOW OUT, DENY IN, DENY OUT
+/// * From: String,          // Source address, port (or "Any")
+/// * To: String,            // Destination address, port (or "Any")
+/// * Protocol: Option<String>  // Protocol name
+/// * Interface: Option<String> // Interface name
 /*
 $  ufw status
 Status: active
@@ -92,8 +94,10 @@ pub fn get() -> Result<Option<AccessLists>> {
 
 /// Add new rules.
 /// This function execute `ufw add` command internally.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// // UFW rule syntax
 /// // allow|deny [in on <dev>] [from <src>] [to <dst>] [port <port>] [proto <protocol>]
 /// let rules_to_add = vec![
@@ -114,8 +118,10 @@ pub fn add(args: &[String]) -> Result<()> {
 
 /// Remove rules.
 /// This function execute `ufw delete` command internally.
+///
 /// # Example
-/// ```
+///
+/// ```ignore
 /// let rules_to_delete = vec![
 ///     "allow from 203.0.113.101".to_string(),
 ///     "allow from 203.0.113.0/24 proto tcp to any port 22".to_string()];


### PR DESCRIPTION
Documentation tests only work with public interface. This PR ignores documentation tests of private modules, and sets up CI to detect such errors early in the future.

Closes #4.