### PR TITLE
Avoid a deadlock with large I/O

### DIFF
--- a/examples/roxer.rs
+++ b/examples/roxer.rs
@@ -256,7 +256,7 @@ where
 {
     let host = "hostname_A";
     if request.host == *host && request.process == "Roxy" {
-        run_roxy::<T>(&request.to_task())
+        run_roxy::<T>(request.to_task())
     } else if request.host == *host && request.process == "Hog" {
         // if I am Hog
         unimplemented!();


### PR DESCRIPTION
With a large amount of data, writing into stdin without reading from stdout may cause a deadlock.