### PR TITLE
Remove unnecessary intermediate `Vec`s

### DIFF
--- a/src/hwinfo.rs
+++ b/src/hwinfo.rs
@@ -27,11 +27,11 @@ pub fn diskusage() -> Result<Option<(String, String, String, String)>> {
         for line in lines {
             if line.starts_with("/dev/") && line.ends_with(DATA_PARTITION) {
                 let after = re.replace_all(line, "$m,$s,$u,$e");
-                let v = after.as_ref().split(',').collect::<Vec<_>>();
-                if let Some(mount) = v.get(0) {
-                    if let Some(size) = v.get(1) {
-                        if let Some(used) = v.get(2) {
-                            if let Some(rate) = v.get(3) {
+                let mut values = after.as_ref().split(',');
+                if let Some(mount) = values.next() {
+                    if let Some(size) = values.next() {
+                        if let Some(used) = values.next() {
+                            if let Some(rate) = values.next() {
                                 return Ok(Some((
                                     (*mount).to_string(),
                                     (*size).to_string(),

--- a/src/ufw.rs
+++ b/src/ufw.rs
@@ -69,10 +69,10 @@ pub fn get() -> Result<Option<AccessLists>> {
                 None
             };
             let after = re_action.replace_all(&after, ",$a $d,");
-            let v = after.split(',').collect::<Vec<_>>();
-            if let Some(to) = v.get(0) {
-                if let Some(action) = v.get(1) {
-                    if let Some(from) = v.get(2) {
+            let mut values = after.split(',');
+            if let Some(to) = values.next() {
+                if let Some(action) = values.next() {
+                    if let Some(from) = values.next() {
                         ret.push((
                             action.trim().to_string(),
                             from.trim().to_string(),


### PR DESCRIPTION
This also fixes clippy warnings with Rust 1.63.