### PR TITLE
Fix bump error of sysinfo 0.31.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -813,17 +813,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "rayon",
- "windows",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -918,7 +917,7 @@ checksum = "f4e71ddbefed856d5881821d6ada4e606bbb91fd332296963ed596e2ad2100f3"
 dependencies = [
  "libc",
  "thiserror",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1003,7 +1002,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
  "windows-targets",
 ]
 
@@ -1012,6 +1021,25 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1"
 serde_json = "1"
 serde_with = "3"
 serde_yaml = "0.9"
-sysinfo = "0.30"
+sysinfo = "0.31"
 systemctl = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }

--- a/src/user/process.rs
+++ b/src/user/process.rs
@@ -50,7 +50,7 @@ pub async fn process_list() -> Vec<Process> {
         let cpu_usage = process.cpu_usage() / num_cpu;
         let mem_usage = process.memory() as f64 / total_memory * 100.0;
         let start_time = process.start_time() as i64 * NANO_SEC;
-        let command = process.name().to_string();
+        let command = process.name().to_string_lossy().to_string();
 
         processes.push(Process {
             user,

--- a/src/user/usg.rs
+++ b/src/user/usg.rs
@@ -50,10 +50,10 @@ pub async fn resource_usage() -> ResourceUsage {
 
     // Calculating CPU usage requires a time interval.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    system.refresh_cpu();
+    system.refresh_cpu_usage();
 
     ResourceUsage {
-        cpu_usage: system.global_cpu_info().cpu_usage(),
+        cpu_usage: system.global_cpu_usage(),
         total_memory: system.total_memory(),
         used_memory: system.used_memory(),
         total_disk_space,

--- a/src/user/usg.rs
+++ b/src/user/usg.rs
@@ -9,10 +9,10 @@ pub struct ResourceUsage {
     /// The average CPU usage in percent.
     pub cpu_usage: f32,
 
-    /// The RAM size in KB.
+    /// The RAM size in bytes.
     pub total_memory: u64,
 
-    /// The amount of used RAM in KB.
+    /// The amount of used RAM in bytes.
     pub used_memory: u64,
 
     /// The total disk space in bytes.


### PR DESCRIPTION
Close #289 
Close #278 

- Fix bump errors of sysinfo 0.31.x.
- Fix unit of memory usage: KB -> bytes
