### PR TITLE
Migrate to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "roxy"
 version = "0.5.1"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 mod interface;
 mod services;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 pub use interface::{Nic, NicOutput};
 use serde::{Deserialize, Serialize};
 pub use services::waitfor_up;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@ mod user;
 
 use std::process::{Command, Stdio};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 pub use common::waitfor_up;
 use common::{NicOutput, Node, NodeRequest, SubCommand};
 use data_encoding::BASE64;
 use serde::Deserialize;
 pub use user::hwinfo::{uptime, version};
-pub use user::process::{process_list, Process};
-pub use user::usg::{resource_usage, ResourceUsage};
+pub use user::process::{Process, process_list};
+pub use user::usg::{ResourceUsage, resource_usage};
 const FAIL_REQUEST: &str = "Failed to create a request";
 
 /// Control services: start, stop, restart, status

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,11 @@ use std::{
 
 use anyhow::{Context, Result};
 use data_encoding::BASE64;
-use root::task::{ExecResult, Task, ERR_INVALID_COMMAND};
+use root::task::{ERR_INVALID_COMMAND, ExecResult, Task};
 use roxy::common::{self, Node, NodeRequest};
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 fn init_tracing() -> Result<WorkerGuard> {
     let log_path = "/opt/clumit/log/roxy.log";

--- a/src/root/hwinfo.rs
+++ b/src/root/hwinfo.rs
@@ -3,7 +3,7 @@ use std::{
     io::Write as IoWrite,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use super::SubCommand;
 

--- a/src/root/ifconfig.rs
+++ b/src/root/ifconfig.rs
@@ -7,7 +7,7 @@ use std::{
     process::Command,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Local};
 use ipnet::IpNet;
 use pnet::datalink::interfaces;
@@ -93,14 +93,14 @@ impl NetplanYaml {
         }
         self.network.ethernets.sort_by(|a, b| a.0.cmp(&b.0));
 
-        if let Some(new_bridges) = newyml.network.bridges {
-            if let Some(self_bridges) = &mut self.network.bridges {
-                for (ifname, bridgecfg) in new_bridges {
-                    if let Some(item) = self_bridges.get_mut(&ifname) {
-                        *item = bridgecfg;
-                    } else {
-                        self_bridges.insert(ifname, bridgecfg);
-                    }
+        if let Some(new_bridges) = newyml.network.bridges
+            && let Some(self_bridges) = &mut self.network.bridges
+        {
+            for (ifname, bridgecfg) in new_bridges {
+                if let Some(item) = self_bridges.get_mut(&ifname) {
+                    *item = bridgecfg;
+                } else {
+                    self_bridges.insert(ifname, bridgecfg);
                 }
             }
         }
@@ -178,11 +178,11 @@ impl NetplanYaml {
 
         let mut from = format!("/tmp/{DEFAULT_NETPLAN_YAML}");
         let mut to = format!("{dir}/{DEFAULT_NETPLAN_YAML}");
-        if let Some((_, _, first)) = files.first() {
-            if first != DEFAULT_NETPLAN_YAML {
-                from = format!("/tmp/{first}");
-                to = format!("{dir}/{first}");
-            }
+        if let Some((_, _, first)) = files.first()
+            && first != DEFAULT_NETPLAN_YAML
+        {
+            from = format!("/tmp/{first}");
+            to = format!("{dir}/{first}");
         }
 
         let mut tmp = OpenOptions::new()
@@ -428,25 +428,25 @@ fn list_files(
         let metadata = fs::metadata(filepath)?;
         let modified: DateTime<Local> = metadata.modified()?.into();
 
-        if let Some(filename) = path.path().file_name() {
-            if let Some(filename) = filename.to_str() {
-                if metadata.is_file() {
-                    files.push((
-                        metadata.len(),
-                        format!("{}", modified.format("%Y/%m/%d %T")),
-                        filename.to_string(),
-                    ));
-                } else if subdir && metadata.is_dir() {
-                    files.push((0, String::new(), filename.to_string()));
-                    /*
-                    // if it's required to traverse the directory recursively, uncomment this code
-                    if let Ok(ret) = list_files(filename, except, subdir) {
-                        for (size, modified_time, name) in ret {
-                            files.push((size, modified_time, format!("{}/{}", filename, name)));
-                        }
+        if let Some(filename) = path.path().file_name()
+            && let Some(filename) = filename.to_str()
+        {
+            if metadata.is_file() {
+                files.push((
+                    metadata.len(),
+                    format!("{}", modified.format("%Y/%m/%d %T")),
+                    filename.to_string(),
+                ));
+            } else if subdir && metadata.is_dir() {
+                files.push((0, String::new(), filename.to_string()));
+                /*
+                // if it's required to traverse the directory recursively, uncomment this code
+                if let Ok(ret) = list_files(filename, except, subdir) {
+                    for (size, modified_time, name) in ret {
+                        files.push((size, modified_time, format!("{}/{}", filename, name)));
                     }
-                    */
                 }
+                */
             }
         }
     }

--- a/src/root/ntp.rs
+++ b/src/root/ntp.rs
@@ -63,12 +63,11 @@ pub(crate) fn get() -> Result<Option<Vec<String>>> {
 
     let mut ret = Vec::new();
     for line in lines {
-        if line.starts_with("server ") {
-            if let Some(cap) = re.captures(line) {
-                if let Some(server) = cap.get(1) {
-                    ret.push(server.as_str().to_string());
-                }
-            }
+        if line.starts_with("server ")
+            && let Some(cap) = re.captures(line)
+            && let Some(server) = cap.get(1)
+        {
+            ret.push(server.as_str().to_string());
         }
     }
     if ret.is_empty() {

--- a/src/root/services.rs
+++ b/src/root/services.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use roxy::common::SubCommand;
 
 pub fn service_control(unit: &str, cmd: SubCommand) -> Result<bool> {

--- a/src/root/sshd.rs
+++ b/src/root/sshd.rs
@@ -63,10 +63,10 @@ pub(crate) fn get() -> Result<u16> {
     for line in lines {
         if line.starts_with("Port ") {
             let s = line.split(' ').collect::<Vec<_>>();
-            if let Some(port) = s.get(1) {
-                if let Ok(port) = port.parse::<u16>() {
-                    return Ok(port);
-                }
+            if let Some(port) = s.get(1)
+                && let Ok(port) = port.parse::<u16>()
+            {
+                return Ok(port);
             }
         }
     }

--- a/src/root/syslog.rs
+++ b/src/root/syslog.rs
@@ -5,7 +5,7 @@ use std::{
     net::SocketAddr,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 const RSYSLOG_CONF: &str = "/etc/rsyslog.d/50-default.conf";
 const DEFAULT_FACILITY: &str = "user.*";
@@ -110,14 +110,14 @@ pub(crate) fn get() -> Result<Option<Vec<(String, String, String)>>> {
             continue;
         };
 
-        if r.len() == 2 {
-            if let Some(first) = r.first() {
-                let facility = (*first).trim().to_string();
-                if let Some(last) = r.last() {
-                    if !last.trim().is_empty() {
-                        ret.push((facility, proto, (*last).to_string()));
-                    }
-                }
+        if r.len() == 2
+            && let Some(first) = r.first()
+        {
+            let facility = (*first).trim().to_string();
+            if let Some(last) = r.last()
+                && !last.trim().is_empty()
+            {
+                ret.push((facility, proto, (*last).to_string()));
             }
         }
     }

--- a/src/root/task.rs
+++ b/src/root/task.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use data_encoding::BASE64;
 use serde::{Deserialize, Serialize};
 

--- a/src/user/hwinfo.rs
+++ b/src/user/hwinfo.rs
@@ -56,17 +56,16 @@ pub fn version() -> (String, String) {
             let lines = contents.lines();
             for line in lines {
                 if line.starts_with("OS:") {
-                    if let Some(pos) = line.find(':') {
-                        if let Some(s) = line.get(pos + 1..) {
-                            os_version = s.trim().to_string();
-                        }
+                    if let Some(pos) = line.find(':')
+                        && let Some(s) = line.get(pos + 1..)
+                    {
+                        os_version = s.trim().to_string();
                     }
-                } else if line.starts_with("Product:") {
-                    if let Some(pos) = line.find(':') {
-                        if let Some(s) = line.get(pos + 1..) {
-                            product_version = s.trim().to_string();
-                        }
-                    }
+                } else if line.starts_with("Product:")
+                    && let Some(pos) = line.find(':')
+                    && let Some(s) = line.get(pos + 1..)
+                {
+                    product_version = s.trim().to_string();
                 }
             }
         }

--- a/src/user/process.rs
+++ b/src/user/process.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use sysinfo::{System, Users, MINIMUM_CPU_UPDATE_INTERVAL};
+use sysinfo::{MINIMUM_CPU_UPDATE_INTERVAL, System, Users};
 
 const KTHREAD_PID: u32 = 2;
 const DEFAULT_USER_NAME: &str = "N/A";


### PR DESCRIPTION
- Apply `cargo fix --edition`
- Revert unnecessary cargo fix changes
- Update Rust edition to 2024
- Run `cargo fmt`

Close #499