### PR TITLE
Fix `set_ntp` to use `SubCommand::Set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Hardened arithmetic in `src/user/usg.rs` against overflow/underflow to ensure
   deterministic behavior across debug and release builds. Replaced raw operators
   with `saturating_add`, `saturating_sub`, and `saturating_mul`.
+- Fix `set_ntp` to apply NTP server updates using `SubCommand::Set`.
 
 ## [0.5.1] - 2025-11-26
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ pub fn get_ntp() -> Result<Option<Vec<String>>> {
 /// * Return error if it fails to build request message
 /// * Return error if `run_roxy` function returns error
 pub fn set_ntp(servers: Vec<String>) -> Result<bool> {
-    if let Ok(req) = NodeRequest::new::<Vec<String>>(Node::Ntp(SubCommand::Get), servers) {
+    if let Ok(req) = NodeRequest::new::<Vec<String>>(Node::Ntp(SubCommand::Set), servers) {
         run_roxy::<bool>(req)
     } else {
         Err(anyhow!(FAIL_REQUEST))
@@ -980,6 +980,24 @@ mod tests {
         let req = ctx.request();
         assert_eq!(req.kind, Node::Ntp(SubCommand::Get));
         assert_none_arg(&req);
+    }
+
+    #[test]
+    fn test_set_ntp_builds_request() {
+        let ctx = TestCtx::new();
+        set_ok(&true);
+        let servers = vec![
+            "time.example.org".to_string(),
+            "time2.example.org".to_string(),
+        ];
+
+        let result = set_ntp(servers.clone()).expect("set_ntp should succeed");
+        assert!(result);
+
+        let req = ctx.request();
+        assert_eq!(req.kind, Node::Ntp(SubCommand::Set));
+        let decoded: Vec<String> = bincode::deserialize(&req.arg).expect("arg should decode");
+        assert_eq!(decoded, servers);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issue
Closes #563

## PR description
Send NTP update requests with the correct subcommand so server changes are applied as intended.
I’m going to address the related tests in https://github.com/aicers/roxy/issues/543